### PR TITLE
Add chat history

### DIFF
--- a/src/viz/components.py
+++ b/src/viz/components.py
@@ -2,12 +2,13 @@
 from dash import dcc, html
 from vizro.models._action._actions_chain import Trigger
 
+from src.viz.actions import _update_chatbot_window
 
 try:
     from pydantic.v1 import validator, Field
 except ImportError:
     from pydantic import validator, Field
-from typing import List, Literal
+from typing import List, Literal, Tuple
 
 import dash_bootstrap_components as dbc
 from dash import html
@@ -77,11 +78,16 @@ class ChatbotWindow(VizroBaseModel):
         type (Literal["render_chatbot"]): Defaults to `"render_chatbot"`.
     """
 
+    data: List[Tuple[str, str]] = None
     type: Literal["render_chatbot"] = "render_chatbot"
 
     @_log_call
     def build(self):
         """Builds chatbot component."""
+        if self.data:
+            chat = [_update_chatbot_window(message) for message in self.data]
+        else:
+            chat = None
         return html.Div(
             [
                 dcc.Store(id="store_conversation", data=[]),
@@ -90,7 +96,7 @@ class ChatbotWindow(VizroBaseModel):
                         dbc.CardBody(
                             [
                                 html.Div(
-                                    html.Div(id=self.id),
+                                    html.Div(id=self.id, children=chat),
                                     className="display-conversation-container",
                                 ),
                             ],


### PR DESCRIPTION
Show the history of the most recent `n=3` (`n` is configurable) chat sessions.

These are shown as tabs because it was quickly and easily to implement; future versions could have a different UI that's more similar to ChatGPT.

Example based on ingesting the vizro docs:
![image](https://github.com/yaronha/demo-llm-agent/assets/49395058/2adb9361-e1de-4104-bf32-9a7262a4ddf4)
