### PR TITLE
New version of chatbot with improved navigation

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -29,7 +29,9 @@ class Client:
             # If the request failed, raise an exception
             response.raise_for_status()
 
-    def list_collections(self, owner=None, metadata=None, names_only=False, short: bool = False):
+    def list_collections(
+        self, owner=None, metadata=None, names_only=False, short: bool = False
+    ):
         response = self.post_request(
             "collections",
             params={
@@ -74,7 +76,9 @@ class Client:
         response = self.post_request(f"session/{session_id}")
         return response["data"]
 
-    def list_sessions(self, username=None, created_after=None, last=None, short: bool = False):
+    def list_sessions(
+        self, username=None, created_after=None, last=None, short: bool = False
+    ):
         response = self.post_request(
             "sessions",
             params={

--- a/src/client.py
+++ b/src/client.py
@@ -29,9 +29,7 @@ class Client:
             # If the request failed, raise an exception
             response.raise_for_status()
 
-    def list_collections(
-        self, owner=None, metadata=None, names_only=False, short: bool = False
-    ):
+    def list_collections(self, owner=None, metadata=None, names_only=False, short: bool = False):
         response = self.post_request(
             "collections",
             params={
@@ -73,12 +71,10 @@ class Client:
         )
 
     def get_session(self, session_id):
-        response = self.post_request(f"sessions/{session_id}")
+        response = self.post_request(f"session/{session_id}")
         return response["data"]
 
-    def list_sessions(
-        self, username=None, created_after=None, last=None, short: bool = False
-    ):
+    def list_sessions(self, username=None, created_after=None, last=None, short: bool = False):
         response = self.post_request(
             "sessions",
             params={

--- a/src/viz/actions.py
+++ b/src/viz/actions.py
@@ -22,7 +22,9 @@ def _update_chatbot_window(message: List[str]) -> html.Div:
 
     if message[0] == "Human":
         thumbnail_human = _create_html_span("person", "thumbnail-human")
-        textbox_human = dbc.Card(text, body=True, inverse=True, class_name="textbox-human")
+        textbox_human = dbc.Card(
+            text, body=True, inverse=True, class_name="textbox-human"
+        )
         return html.Div([thumbnail_human, textbox_human])
     elif message[0] == "AI":
         thumbnail = _create_html_span("robot_2", "thumbnail-ai")

--- a/src/viz/actions.py
+++ b/src/viz/actions.py
@@ -22,9 +22,7 @@ def _update_chatbot_window(message: List[str]) -> html.Div:
 
     if message[0] == "Human":
         thumbnail_human = _create_html_span("person", "thumbnail-human")
-        textbox_human = dbc.Card(
-            text, body=True, inverse=True, class_name="textbox-human"
-        )
+        textbox_human = dbc.Card(text, body=True, inverse=True, class_name="textbox-human")
         return html.Div([thumbnail_human, textbox_human])
     elif message[0] == "AI":
         thumbnail = _create_html_span("robot_2", "thumbnail-ai")
@@ -37,44 +35,3 @@ def _update_chatbot_window(message: List[str]) -> html.Div:
         return html.Div([thumbnail, textbox])
     else:
         raise ValueError("Incorrect option for `box`.")
-
-
-# TODO: find a way to avoid double action creation if we wanted to use the button
-@capture("action")
-def submit_message_store(
-    user_input_value: str, store_conversation: List[List[str]]
-) -> Tuple[List[List[str]], List[html.Div], str]:
-    """Add message to store, and update the chat and input windows."""
-    if not user_input_value:
-        raise dash.exceptions.PreventUpdate
-
-    store_conversation.append(["Human", user_input_value])
-
-    chat_messages = [_update_chatbot_window(message) for message in store_conversation]
-
-    thumbnail = _create_html_span("robot_2", "thumbnail-ai")
-    textbox = dbc.Card("Thinking...", body=True, inverse=False, class_name="textbox-ai")
-    loader = html.Div([thumbnail, textbox])
-    chat_messages.append(loader)
-
-    return store_conversation, chat_messages, ""
-
-
-@capture("action")
-def update_chatbot_window_from_store(store_conversation: List[List[str]]):
-    """Update the chatbot window with the conversation result."""
-    chat_messages = [_update_chatbot_window(message) for message in store_conversation]
-    return chat_messages
-
-
-submit = vm.Action(
-    function=submit_message_store(),
-    inputs=["user_input_id.value", "store_conversation.data"],
-    outputs=["store_conversation.data", "chatbot.children", "user_input_id.value"],
-)
-
-update = vm.Action(
-    function=update_chatbot_window_from_store(),
-    inputs=["store_conversation.data"],
-    outputs=["chatbot.children"],
-)

--- a/src/viz/app.py
+++ b/src/viz/app.py
@@ -1,21 +1,26 @@
+import logging
 import os
 import uuid
 from typing import Literal, Dict
 
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:  # pragma: no cov
+    from pydantic import Field, validator
 import dash
-from dash import Input, Output, State, MATCH, ALL
-import dash_cytoscape as cyto
-import pandas as pd
+from dash import Patch
+import dash_bootstrap_components as dbc
 import vizro.models as vm
-from dash import html, dcc
+from dash import dcc
 from vizro import Vizro
+from vizro.models import Page
 from vizro.models._components.form._user_input import UserInput
+from vizro.models._page import _PageBuildType
 from vizro.models.types import capture
-from vizro.tables import dash_data_table
 
 from src.client import Client
-from src.viz.actions import submit, update
-from src.viz.components import ChatbotWindow, CustomUserInput
+from src.viz.actions import _update_chatbot_window
+from src.viz.components import ChatbotWindow, TextArea
 
 ##
 # Set this to True while developing. This will enable hot reloading so that
@@ -23,139 +28,69 @@ from src.viz.components import ChatbotWindow, CustomUserInput
 # in the console
 DEBUG = False
 client = Client(os.environ.get("AGENT_API_URL", "http://localhost:8000"))
-session_id = uuid.uuid4().hex
+this_session_id = uuid.uuid4().hex
 
 
+##########################
+# Main API calls
 def get_collections():
     """get the available indices from the back end"""
     return client.list_collections(names_only=True)
 
 
-@capture("action")
-def submit_ingest(n_clicks: int, data_path: str, collection: str, loader: str, extra_params: Dict[str, str]):
-    """What happens when you click the Submit button."""
-    # Prevent trigger on page load
-    if not n_clicks:
-        return
-    client.ingest(collection, path=data_path, loader=loader)
-    print(data_path, collection, extra_params)
-
-
 # Used on chatbot screen
-def get_llm_response(user_input: str, collection) -> str:
+def query_llm(user_input: str, collection) -> str:
     """What happens when you send a message to the chatbot."""
-    bot_message, sources, state = client.query(user_input, collection=collection, session_id=session_id)
+    bot_message, sources, state = client.query(user_input, collection=collection, session_id=this_session_id)
     if sources:
         bot_message += "\n" + sources
-    return bot_message
+    # No need to return anything since chat is populated from session history
+    # This means the sources are ignored
+    # return bot_message
 
 
-@capture("action")
-def new_collection(n_clicks: int, name, description, category):
-    if not n_clicks:
-        return
-    client.create_collection(name, description=description, db_category=category)
-    return pd.DataFrame(client.list_collections(names_only=False)).to_dict("records")
-
-
-def get_flowchart_elements():
-    """Nodes and edges for the flowchart."""
-    nodes = [
-        {"id": "0", "label": "SessionLoader"},
-        {"id": "1", "label": "RefineQuery"},
-        {"id": "2", "label": "MultiRetriever"},
-        {"id": "3", "label": "HistorySaver"},
-    ]
-    edges = [
-        {"source": "0", "target": "1"},
-        {"source": "1", "target": "2"},
-        {"source": "2", "target": "3"},
-    ]
-
-    return nodes + edges
-
-
-def get_recent_chat_histories(n: int):
-    """Get most recent n chat histories. Only searches through the last 10 sessions.
+def get_recent_chat_histories(n: int = None):
+    """Get most recent n chat histories. Searches through all sessions.
     Gives most recent history first."""
-    sessions = client.list_sessions(last=10)
+    sessions = client.list_sessions()
     histories = []
 
     for session in sessions:
         # TODO: Should really be a yield until have n entries
         if not session["history"]:
             continue
-        histories.append([(line["role"], line["content"]) for line in session["history"]])
+        histories.append((session["session_id"], format_session_history(session)))
 
-    return histories[:n]
-
-
-class Flowchart(vm.VizroBaseModel):
-    type: Literal["flowchart"] = "flowchart"
-
-    def build(self):
-        return html.Div(
-            [
-                cyto.Cytoscape(
-                    layout={
-                        "name": "breadthfirst",
-                        "directed": True,
-                        "spacingFactor": 1,
-                    },
-                    style={"width": "100%", "height": "400px"},
-                    stylesheet=[
-                        {
-                            "selector": "node",
-                            "style": {
-                                "content": "data(label)",
-                                "shape": "rectangle",
-                                "background-color": "rgba(255, 255, 255, 0.88)",
-                                "padding": "4px 8px",
-                                "width": "100%",
-                                "height": "20px",
-                                "color": "rgba(20, 23, 33, 0.88)",
-                                "font-size": "12px",
-                                "text-wrap": "wrap",
-                                "text-halign": "center",
-                                "text-valign": "center",
-                                "border-color": "#D3D7E0",
-                                "border-width": 1,
-                            },
-                        },
-                        {
-                            "selector": "edge",
-                            "style": {
-                                "width": 1,
-                                "line-color": "#D3D7E0",
-                                "target-arrow-color": "#D3D7E0",
-                                "target-arrow-shape": "triangle",
-                                "curve-style": "bezier",
-                            },
-                        },
-                    ],
-                    elements=[{"data": element} for element in get_flowchart_elements()],
-                )
-            ]
-        )
+    return histories if n is None else histories[:n]
 
 
-# Force style to remain as grid to override grid-layout selector
-class GridLayout(vm.Layout):
-    def build(self):
-        layout = super().build()
-        layout.style = {**layout.style, "display": "grid"}
-        return layout
+##########################
+# Helper functions
+def format_session_history(session):
+    if not session or not session["history"]:
+        return []
+    return [(line["role"], line["content"]) for line in session["history"]]
 
 
-class UserInputWithValue(UserInput):
-    value: str = None
+@capture("action")
+def add_thinking_box(user_input_value):
+    if not user_input_value:
+        raise dash.exceptions.PreventUpdate
+    chatbot_children = Patch()
+    chatbot_children.append(_update_chatbot_window(["Human", user_input_value]))
+    chatbot_children.append(_update_chatbot_window(["AI", "Thinking..."]))
 
-    def build(self):
-        built = super().build()
-        if self.value:
-            built[self.id].value = self.value
-        built.className = "input-container"
-        return built
+    return chatbot_children, "", user_input_value
+
+
+@capture("action")
+def run_chatbot(stored_user_input_value, collection):
+    """Chatbot interaction."""
+    query_llm(stored_user_input_value, collection)
+    return [
+        _update_chatbot_window(message)
+        for message in format_session_history(client.get_session(session_id=this_session_id))
+    ]
 
 
 # Enable form components to appear in vm.Container and vm.Page.
@@ -166,10 +101,8 @@ vm.Container.add_type("components", vm.RadioItems)
 vm.Container.add_type("components", vm.RangeSlider)
 vm.Container.add_type("components", vm.Slider)
 vm.Container.add_type("components", UserInput)
-vm.Page.add_type("components", UserInputWithValue)
-vm.Page.add_type("components", ChatbotWindow)
-vm.Page.add_type("components", CustomUserInput)
-vm.Page.add_type("components", Flowchart)
+vm.Container.add_type("components", TextArea)
+vm.Container.add_type("components", ChatbotWindow)
 
 vm.Page.add_type("components", vm.Checklist)
 vm.Page.add_type("components", vm.Dropdown)
@@ -177,248 +110,103 @@ vm.Page.add_type("components", vm.RadioItems)
 vm.Page.add_type("components", vm.RangeSlider)
 vm.Page.add_type("components", vm.Slider)
 vm.Page.add_type("components", UserInput)
-vm.Page.add_type("components", UserInputWithValue)
-vm.Container.add_type("components", ChatbotWindow)
-vm.Container.add_type("components", CustomUserInput)
-vm.Container.add_type("components", Flowchart)
+vm.Page.add_type("components", TextArea)
+vm.Page.add_type("components", ChatbotWindow)
 
 
-@capture("action")
-def run_chatbot(store_conversation, collection):  # need store_conversation as input
-    """Chatbot interaction."""
-    # Get the user input
-    user_input_value = store_conversation[-1][1]
-    store_conversation.append(("AI", get_llm_response(user_input_value, collection)))
-    return store_conversation
-
-
-def make_parameter_div(id, parameter_name, parameter_value, placeholder=True):
-    div = html.Div(
-        [
-            vm.Button.construct(id={"type": "delete_parameter", "id": id}, text="Delete").build(),
-            UserInput.construct(id={"type": "parameter_name", "id": id}, placeholder=parameter_name).build(),
-            UserInput.construct(id={"type": "parameter_value", "id": id}, placeholder=parameter_value).build(),
+this_session_chatbot_components = [
+    ChatbotWindow(id="chatbot"),
+    TextArea(id="user_input_id", placeholder="Write a message and press Submit..."),
+    vm.Dropdown(
+        id="chatbot_collection",
+        title="Select data collection",
+        options=get_collections(),
+        multi=False,
+        value="default",
+    ),
+    vm.Button(
+        text="Submit",
+        id="submit",
+        actions=[
+            vm.Action(
+                function=add_thinking_box(),  # inputs and outputs need to match above defined
+                inputs=["user_input_id.value"],
+                outputs=["chatbot.children", "user_input_id.value", "store_conversation.data"],
+            ),
+            vm.Action(
+                function=run_chatbot(),  # inputs and outputs need to match above defined action
+                inputs=["store_conversation.data", "chatbot_collection.value"],
+                outputs=["chatbot.children"],
+            ),
         ],
-        className="parameter",
-        id={"type": "parameter_container", "id": id},
-    )
-    if not placeholder:
-        div[{"type": "parameter_name", "id": id}].value = parameter_name
-        div[{"type": "parameter_value", "id": id}].value = parameter_value
-    return div
-
-
-@dash.callback(
-    Output("page-components", "children"),
-    inputs={"n_clicks": Input("add_parameter", "n_clicks"), "page_components": State("page-components", "children")},
-)
-def add_parameter(n_clicks, page_components):
-    # n_clicks = n_clicks or 0  # Since id should be an integer
-    if not n_clicks:
-        return dash.no_update
-
-    # Use construct to avoid validation rejecting the id as non-string and also to avoid the DuplicateIDError.
-    # Insert above the Add parameter button rather than below it as append would do.
-    page_components.insert(-3, make_parameter_div(n_clicks, "Parameter name", "Parameter value"))
-    return page_components
-
-
-@dash.callback(
-    output=[
-        Output({"type": "parameter_container", "id": MATCH}, "style", allow_duplicate=True),
-    ],
-    inputs={
-        "delete_parameter": Input({"type": "delete_parameter", "id": MATCH}, "n_clicks"),
-    },
-    prevent_initial_call=True,
-)
-def delete_parameter(delete_parameter):
-    # Note this doesn't actually delete the data from the store.
-    if not delete_parameter:
-        return dash.no_update
-
-    return [{"display": "none"}]
-
-
-# Callback for all the keyword parameters
-@dash.callback(
-    Output("form_data", "data", allow_duplicate=True),
-    inputs={
-        "parameter_names": Input({"type": "parameter_name", "id": ALL}, "value"),
-        "parameter_values": Input({"type": "parameter_value", "id": ALL}, "value"),
-        "form_data": State("form_data", "data"),
-    },
-    prevent_initial_call=True,
-)
-def update_form_data_for_parameters(parameter_names, parameter_values, form_data):
-    for parameter_name, parameter_value in zip(parameter_names, parameter_values):
-        # Don't include empty strings
-        if parameter_name:
-            form_data[parameter_name] = parameter_value
-    return form_data
-
-
-pages = []
-
-chat_histories = [
-    vm.Container(title=f"Previous chat {i}", components=[ChatbotWindow(data=chat_history)])
-    for i, chat_history in enumerate(get_recent_chat_histories(3), 1)
+    ),
 ]
 
 
-pages.append(
-    vm.Page(
-        title="Chatbot",
-        components=[
-            vm.Tabs(
-                tabs=[
-                    vm.Container(
-                        title="Current chat",
-                        components=[
-                            ChatbotWindow(id="chatbot"),
-                            CustomUserInput(
-                                id="user_input_id",
-                                placeholder="Send a message and press enter...",
-                                actions=[
-                                    submit,
-                                    vm.Action(
-                                        function=run_chatbot(),  # inputs and outputs need to match above defined action
-                                        inputs=["store_conversation.data", "chatbot_collection.value"],
-                                        outputs=["store_conversation.data"],
-                                    ),
-                                    update,
-                                ],
-                            ),
-                            vm.Dropdown(
-                                id="chatbot_collection",
-                                title="Select data collection",
-                                options=get_collections(),
-                                multi=False,
-                                value="default",
-                            ),
-                        ],
-                    ),
-                    *chat_histories,
-                ]
-            ),
-        ],
-    )
-)
+class ChatbotPage(vm.Page):
+    def build(self, session_id=this_session_id) -> _PageBuildType:
+        self.title = "Current chat" if session_id == this_session_id else session_id[:5]
 
-pages.append(
-    vm.Page(
-        title="Ingest data",
-        components=[
-            UserInputWithValue(
-                id="data_path",
-                title="Data path",
-                value="http://www.example.com/data",
-            ),
-            vm.Dropdown(
-                id="collection",
-                title="Select data collection",
-                options=get_collections(),
-                multi=False,
-            ),
-            vm.Dropdown(
-                id="loader",
-                title="Select document loader type",
-                options=["web", "eweb", "file"],
-                multi=False,
-            ),
-            vm.Button(id="add_parameter", text="Add parameter"),
-            vm.Button(
-                id="submit_ingest",
-                text="Submit",
-                actions=[
-                    vm.Action(
-                        function=submit_ingest(),
-                        inputs=[
-                            "submit_ingest.n_clicks",
-                            "data_path.value",
-                            "collection.value",
-                            "loader.value",
-                            "form_data.data",
-                        ],
-                    )
-                ],
-            ),
-        ],
-    )
-)
+        if session_id == this_session_id:
+            self.components = this_session_chatbot_components
+        else:
+            self.components = [ChatbotWindow(data=format_session_history(client.get_session(session_id=session_id)))]
+        self.layout = vm.Layout(grid=[[i] for i in range(len(self.components))])
 
-data = client.list_collections(names_only=False)
-df = pd.DataFrame(data)
+        built = super().build()
+        if session_id == this_session_id:
+            # Need to repopulate so when you switch back to current chat page it is still populated
+            built["chatbot"].children = [
+                _update_chatbot_window(message)
+                for message in format_session_history(client.get_session(session_id=session_id))
+            ]
+        return built
 
-pages.append(
-    vm.Page(
-        title="Data",
-        components=[
-            vm.Container(
-                title="Create New Collection",
-                layout=GridLayout(grid=[[0, 1, 2], [3, 3, 3]]),
-                components=[
-                    UserInput(
-                        id="collection_name",
-                        title="Collection name",
-                    ),
-                    UserInput(id="collection_desc", title="Description"),
-                    vm.Dropdown(
-                        id="collection_type",
-                        title="Type",
-                        options=["vector"],
-                        multi=False,
-                    ),
-                    vm.Button(
-                        id="add_collection",
-                        text="Create",
-                        actions=[
-                            vm.Action(
-                                function=new_collection(),
-                                inputs=[
-                                    "add_collection.n_clicks",
-                                    "collection_name.value",
-                                    "collection_desc.value",
-                                    "collection_type.value",
-                                ],
-                                outputs=["data_collections.data"],
-                            )
-                        ],
-                    ),
-                ],
-            ),
-            vm.Table(
-                title="Data Collections",
-                figure=dash_data_table(id="data_collections", data_frame=df),
-            ),
-        ],
-    )
-)
 
-sdata = client.list_sessions(short=True)
-# The state column has difficulty with JSONifying and pandas DataFrame, so remove it
-sdf = pd.DataFrame(sdata).drop(columns=["state"], errors="ignore")
+page = ChatbotPage(title="Chatbot", components=[ChatbotWindow()])
 
-pages.append(
-    vm.Page(
-        title="Sessions",
-        components=[
-            vm.Table(title="Chat sessions", figure=dash_data_table(id="sessions_tbl", data_frame=sdf)),
-        ],
-        controls=[vm.Filter(column="username")],
-    )
-)
 
-pages.append(
-    vm.Page(
-        title="Pipeline",
-        components=[Flowchart()],
-    )
-)
+class ChatbotDashboard(vm.Dashboard):
+    # Needed to pass session_id through as query parameter
+    def _make_page_layout(self, page: Page, session_id=this_session_id):
+        page_divs = self._get_page_divs(page=page)
+        page_content: _PageBuildType = page.build(session_id)
+        control_panel = page_content["control-panel"]
+        page_components = page_content["page-components"]
+        page_divs["control-panel"] = control_panel
+        page_divs["page-components"] = page_components
+        page_divs["page-title"].children = page.title
+        return self._arrange_page_divs(page_divs=page_divs)
 
+
+class ChatAccordion(vm.Accordion):
+    # Removed validation that checks dash page registry
+    def _create_accordion_buttons(self, pages, active_page_id):
+        """Creates a button for each provided page that is registered."""
+        accordion_buttons = []
+
+        for session_id in pages:
+            session_name = "Current chat" if session_id == this_session_id else session_id[:5]
+            accordion_buttons.append(
+                dbc.Button(
+                    children=[session_name],
+                    className="accordion-item-button",
+                    active=False,  # page["session_id"] == active_page_id,
+                    href="?session_id=" + session_id,
+                )
+            )
+        return accordion_buttons
+
+
+ChatAccordion.__fields__["pages"].validators = []
+ChatAccordion.__fields__["pages"].post_validators = None
+
+sessions = [this_session_id] + [session_id for session_id, session_history in get_recent_chat_histories()]
 
 if __name__ == "__main__":
-    dashboard = vm.Dashboard(title="LLM Demo App", pages=pages)
+    dashboard = ChatbotDashboard(
+        title="LLM Demo App", pages=[page], navigation=vm.Navigation(nav_selector=ChatAccordion(pages=sessions))
+    )
     app = Vizro().build(dashboard)
     app.dash.layout.children.append(dcc.Store(id="form_data", data={}))
     app.run(debug=DEBUG)

--- a/src/viz/app.py
+++ b/src/viz/app.py
@@ -41,7 +41,9 @@ def get_collections():
 # Used on chatbot screen
 def query_llm(user_input: str, collection) -> str:
     """What happens when you send a message to the chatbot."""
-    bot_message, sources, state = client.query(user_input, collection=collection, session_id=this_session_id)
+    bot_message, sources, state = client.query(
+        user_input, collection=collection, session_id=this_session_id
+    )
     if sources:
         bot_message += "\n" + sources
     # No need to return anything since chat is populated from session history
@@ -89,7 +91,9 @@ def run_chatbot(stored_user_input_value, collection):
     query_llm(stored_user_input_value, collection)
     return [
         _update_chatbot_window(message)
-        for message in format_session_history(client.get_session(session_id=this_session_id))
+        for message in format_session_history(
+            client.get_session(session_id=this_session_id)
+        )
     ]
 
 
@@ -131,7 +135,11 @@ this_session_chatbot_components = [
             vm.Action(
                 function=add_thinking_box(),  # inputs and outputs need to match above defined
                 inputs=["user_input_id.value"],
-                outputs=["chatbot.children", "user_input_id.value", "store_conversation.data"],
+                outputs=[
+                    "chatbot.children",
+                    "user_input_id.value",
+                    "store_conversation.data",
+                ],
             ),
             vm.Action(
                 function=run_chatbot(),  # inputs and outputs need to match above defined action
@@ -150,7 +158,13 @@ class ChatbotPage(vm.Page):
         if session_id == this_session_id:
             self.components = this_session_chatbot_components
         else:
-            self.components = [ChatbotWindow(data=format_session_history(client.get_session(session_id=session_id)))]
+            self.components = [
+                ChatbotWindow(
+                    data=format_session_history(
+                        client.get_session(session_id=session_id)
+                    )
+                )
+            ]
         self.layout = vm.Layout(grid=[[i] for i in range(len(self.components))])
 
         built = super().build()
@@ -158,7 +172,9 @@ class ChatbotPage(vm.Page):
             # Need to repopulate so when you switch back to current chat page it is still populated
             built["chatbot"].children = [
                 _update_chatbot_window(message)
-                for message in format_session_history(client.get_session(session_id=session_id))
+                for message in format_session_history(
+                    client.get_session(session_id=session_id)
+                )
             ]
         return built
 
@@ -186,7 +202,9 @@ class ChatAccordion(vm.Accordion):
         accordion_buttons = []
 
         for session_id in pages:
-            session_name = "Current chat" if session_id == this_session_id else session_id[:5]
+            session_name = (
+                "Current chat" if session_id == this_session_id else session_id[:5]
+            )
             accordion_buttons.append(
                 dbc.Button(
                     children=[session_name],
@@ -201,11 +219,15 @@ class ChatAccordion(vm.Accordion):
 ChatAccordion.__fields__["pages"].validators = []
 ChatAccordion.__fields__["pages"].post_validators = None
 
-sessions = [this_session_id] + [session_id for session_id, session_history in get_recent_chat_histories()]
+sessions = [this_session_id] + [
+    session_id for session_id, session_history in get_recent_chat_histories()
+]
 
 if __name__ == "__main__":
     dashboard = ChatbotDashboard(
-        title="LLM Demo App", pages=[page], navigation=vm.Navigation(nav_selector=ChatAccordion(pages=sessions))
+        title="LLM Demo App",
+        pages=[page],
+        navigation=vm.Navigation(nav_selector=ChatAccordion(pages=sessions)),
     )
     app = Vizro().build(dashboard)
     app.dash.layout.children.append(dcc.Store(id="form_data", data={}))

--- a/src/viz/components.py
+++ b/src/viz/components.py
@@ -62,15 +62,6 @@ class TextArea(VizroBaseModel):
         )
 
 
-class CustomUserInput(TextArea):
-    """Custom input form."""
-
-    @validator("actions")
-    def _validate_actions(cls, v, values):
-        v[0].trigger = Trigger(component_id=values["id"], component_property="n_submit")
-        return v
-
-
 class ChatbotWindow(VizroBaseModel):
     """Component to render chatbot.
 

--- a/src/viz/components.py
+++ b/src/viz/components.py
@@ -2,12 +2,13 @@
 from dash import dcc, html
 from vizro.models._action._actions_chain import Trigger
 
+from src.viz.actions import _update_chatbot_window
 
 try:
     from pydantic.v1 import validator, Field
 except ImportError:
     from pydantic import validator, Field
-from typing import List, Literal
+from typing import List, Literal, Tuple
 
 import dash_bootstrap_components as dbc
 from dash import html
@@ -77,11 +78,16 @@ class ChatbotWindow(VizroBaseModel):
         type (Literal["render_chatbot"]): Defaults to `"render_chatbot"`.
     """
 
+    data: List[Tuple[str, str]] = None
     type: Literal["render_chatbot"] = "render_chatbot"
 
     @_log_call
     def build(self):
         """Builds chatbot component."""
+        if self.data:
+            chat = [_update_chatbot_window(message) for message in self.data]
+        else:
+            chat = None
         return html.Div(
             [
                 dcc.Store(id="store_conversation", data=[]),
@@ -90,7 +96,7 @@ class ChatbotWindow(VizroBaseModel):
                         dbc.CardBody(
                             [
                                 html.Div(
-                                    html.Div(id=self.id),
+                                    html.Div(id=self.id, children=chat),
                                     className="display-conversation-container",
                                 ),
                             ],


### PR DESCRIPTION
* Removed all screens other than chatbot
* Older chat sessions are available down the left navigation bar
* Much more robust, e.g. switching between these pages will no longer lose your current chat
* Pressing enter no longer submits the query; you need to press the Submit button instead

❗There are three big catches here though:
1. the chat screen is always fetched from the database history rather than from the response of `client.query`. This ensures consistency and robustness but means that **sources are no longer displayed** because they're not persisted to the history in the database. To change this, the code in `query_llm` that does `bot_message + sources` should move so that sources are included in the db.
2. the topic of a session exists as a column in the db but is not populated anywhere, and so everywhere you need a session name I just use session_id instead. This means that **chat titles are just random hex strings**. To change this the session topic need to be populated.
3. since the navigation bar has been hijacked to switch between chats, it's not easy to embed this into a larger app with other screens - it's just a **single standalone one** now.

![image](https://github.com/yaronha/demo-llm-agent/assets/49395058/fd2ec6fc-b696-4bd0-bf3b-3ea28e0fcabf)
